### PR TITLE
Remove jekyll-archives gem from config.yml

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,8 +17,6 @@ GEM
       pathutil (~> 0.9)
       rouge (~> 1.7)
       safe_yaml (~> 1.0)
-    jekyll-archives (2.1.1)
-      jekyll (>= 2.4)
     jekyll-feed (0.8.0)
       jekyll (~> 3.3)
     jekyll-paginate (1.1.0)
@@ -51,11 +49,10 @@ PLATFORMS
 
 DEPENDENCIES
   jekyll (= 3.3.1)
-  jekyll-archives (= 2.1.1)
   jekyll-feed (= 0.8.0)
   jekyll-paginate (= 1.1.0)
   jekyll-seo-tag (= 2.1.0)
   jekyll-sitemap (= 0.12.0)
 
 BUNDLED WITH
-   1.12.5
+   1.14.6

--- a/_config.yml
+++ b/_config.yml
@@ -49,12 +49,7 @@ defaults:
       layout: "default"
       push_sidebar_down: true
 
-jekyll-archives:
-  enabled:
-    - categories
-
 gems:
-  - jekyll-archives
   - jekyll-sitemap
   - jekyll-seo-tag
   - jekyll-feed


### PR DESCRIPTION
Jekyll-archives was removed from the gemfile in one of the previous commits breaking the build. When running `bundle exec jekyll serve` I see this: 

![screen shot 2017-03-16 at 11 41 31 am](https://cloud.githubusercontent.com/assets/3294043/24013599/2bff6fa6-0a3f-11e7-9bf0-8b8554940c90.png)

(Sorry about the small image. click to enlarge)
I have updated the config.yml file to reflect jekyll-archives removal. 

New to jekyll, hope this PR works.