### PR TITLE
Include baseurl in post link.

### DIFF
--- a/_includes/post-heading.html
+++ b/_includes/post-heading.html
@@ -4,7 +4,7 @@
 	</div>
 {% endif %}
 <h1>
-	<a href="{{ include.post.url }}">
+	<a href="{{ site.baseurl }}{{ include.post.url }}">
 		{{ include.post.title }}
 	</a>
 </h1>


### PR DESCRIPTION
I have my site deployed with github sites and it includes a baseurl. This change fixes an incomplete link. If baseurl is not set, this will make no change to the link.